### PR TITLE
database_itemの作成と更新を行うメソッドを追加。

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,3 +6,6 @@ Style/StringLiterals:
 
 Style/StringLiteralsInInterpolation:
   EnforcedStyle: double_quotes
+
+Metrics/MethodLength:
+  Max: 20

--- a/lib/crs/notion/client.rb
+++ b/lib/crs/notion/client.rb
@@ -28,15 +28,15 @@ module Crs
 
       def create_database_item(database_id:, properties:)
         endpoint = "https://api.notion.com/v1/pages"
-        
+
         body = {
           parent: { database_id: database_id },
           properties: properties
         }
-        
+
         response = ::HTTParty.post(endpoint, headers: headers, body: body.to_json)
         raise "Notion API Error: #{response.code}, #{response.message}" if response.code != 200
-        
+
         JSON.parse(response.body)
       end
 
@@ -46,14 +46,14 @@ module Crs
       # @return [Hash] 更新されたアイテムの情報
       def update_database_item(item_id:, properties:)
         endpoint = "https://api.notion.com/v1/pages/#{item_id}"
-        
+
         body = {
           properties: properties
         }
-        
+
         response = ::HTTParty.patch(endpoint, headers: headers, body: body.to_json)
         raise "Notion API Error: #{response.code}, #{response.message}" if response.code != 200
-        
+
         JSON.parse(response.body)
       end
     end

--- a/lib/crs/notion/client.rb
+++ b/lib/crs/notion/client.rb
@@ -39,6 +39,23 @@ module Crs
         
         JSON.parse(response.body)
       end
+
+      # データベースアイテムを更新するメソッド
+      # @param id [String] 更新するアイテム（ページ）のID
+      # @param properties [Hash] 更新するプロパティの情報
+      # @return [Hash] 更新されたアイテムの情報
+      def update_database_item(item_id:, properties:)
+        endpoint = "https://api.notion.com/v1/pages/#{item_id}"
+        
+        body = {
+          properties: properties
+        }
+        
+        response = ::HTTParty.patch(endpoint, headers: headers, body: body.to_json)
+        raise "Notion API Error: #{response.code}, #{response.message}" if response.code != 200
+        
+        JSON.parse(response.body)
+      end
     end
   end
 end

--- a/lib/crs/notion/client.rb
+++ b/lib/crs/notion/client.rb
@@ -25,6 +25,20 @@ module Crs
 
         JSON.parse(response.body)
       end
+
+      def create_database_item(database_id:, properties:)
+        endpoint = "https://api.notion.com/v1/pages"
+        
+        body = {
+          parent: { database_id: database_id },
+          properties: properties
+        }
+        
+        response = ::HTTParty.post(endpoint, headers: headers, body: body.to_json)
+        raise "Notion API Error: #{response.code}, #{response.message}" if response.code != 200
+        
+        JSON.parse(response.body)
+      end
     end
   end
 end

--- a/spec/crs/notion/client_spec.rb
+++ b/spec/crs/notion/client_spec.rb
@@ -190,6 +190,430 @@ RSpec.describe Crs::Notion::Client do
     end
   end
 
+  describe "#create_database_item" do
+    let(:database_id) { "67890abc-1234-5678-9abc-def123456789" }
+    let(:properties) do
+      {
+        "Name" => {
+          "title" => [
+            {
+              "text" => {
+                "content" => "Test Item"
+              }
+            }
+          ]
+        },
+        "Description" => {
+          "rich_text" => [
+            {
+              "text" => {
+                "content" => "This is a test description"
+              }
+            }
+          ]
+        }
+      }
+    end
+    let(:endpoint) { "https://api.notion.com/v1/pages" }
+    let(:request_body) do
+      {
+        parent: { database_id: database_id },
+        properties: properties
+      }
+    end
+    let(:sample_response) do
+      {
+        "object" => "page",
+        "id" => "def123-4567-89ab-cdef-123456789abc",
+        "created_time" => "2023-01-01T00:00:00.000Z",
+        "last_edited_time" => "2023-01-01T00:00:00.000Z",
+        "parent" => {
+          "type" => "database_id",
+          "database_id" => database_id
+        },
+        "properties" => properties
+      }
+    end
+
+    context "when API call is successful" do
+      let(:mock_response) do
+        double("HTTParty::Response",
+               code: 200,
+               body: sample_response.to_json)
+      end
+
+      before do
+        allow(HTTParty).to receive(:post)
+          .with(endpoint, headers: client.headers, body: request_body.to_json)
+          .and_return(mock_response)
+      end
+
+      it "returns parsed JSON response" do
+        result = client.create_database_item(database_id: database_id, properties: properties)
+        expect(result).to eq(sample_response)
+      end
+
+      it "calls HTTParty.post with correct parameters" do
+        client.create_database_item(database_id: database_id, properties: properties)
+        expect(HTTParty).to have_received(:post)
+          .with(endpoint, headers: client.headers, body: request_body.to_json)
+      end
+    end
+
+    context "when API call fails with 400 Bad Request" do
+      let(:mock_response) do
+        double("HTTParty::Response",
+               code: 400,
+               message: "Bad Request")
+      end
+
+      before do
+        allow(HTTParty).to receive(:post)
+          .with(endpoint, headers: client.headers, body: request_body.to_json)
+          .and_return(mock_response)
+      end
+
+      it "raises an error with appropriate message" do
+        expect { client.create_database_item(database_id: database_id, properties: properties) }
+          .to raise_error(RuntimeError, "Notion API Error: 400, Bad Request")
+      end
+    end
+
+    context "when API call fails with 401 Unauthorized" do
+      let(:mock_response) do
+        double("HTTParty::Response",
+               code: 401,
+               message: "Unauthorized")
+      end
+
+      before do
+        allow(HTTParty).to receive(:post)
+          .with(endpoint, headers: client.headers, body: request_body.to_json)
+          .and_return(mock_response)
+      end
+
+      it "raises an error with appropriate message" do
+        expect { client.create_database_item(database_id: database_id, properties: properties) }
+          .to raise_error(RuntimeError, "Notion API Error: 401, Unauthorized")
+      end
+    end
+
+    context "when API call fails with 404 Not Found" do
+      let(:mock_response) do
+        double("HTTParty::Response",
+               code: 404,
+               message: "Not Found")
+      end
+
+      before do
+        allow(HTTParty).to receive(:post)
+          .with(endpoint, headers: client.headers, body: request_body.to_json)
+          .and_return(mock_response)
+      end
+
+      it "raises an error with appropriate message" do
+        expect { client.create_database_item(database_id: database_id, properties: properties) }
+          .to raise_error(RuntimeError, "Notion API Error: 404, Not Found")
+      end
+    end
+
+    context "when API call fails with 500 Internal Server Error" do
+      let(:mock_response) do
+        double("HTTParty::Response",
+               code: 500,
+               message: "Internal Server Error")
+      end
+
+      before do
+        allow(HTTParty).to receive(:post)
+          .with(endpoint, headers: client.headers, body: request_body.to_json)
+          .and_return(mock_response)
+      end
+
+      it "raises an error with appropriate message" do
+        expect { client.create_database_item(database_id: database_id, properties: properties) }
+          .to raise_error(RuntimeError, "Notion API Error: 500, Internal Server Error")
+      end
+    end
+
+    context "when response body contains invalid JSON" do
+      let(:mock_response) do
+        double("HTTParty::Response",
+               code: 200,
+               body: "{invalid json}")
+      end
+
+      before do
+        allow(HTTParty).to receive(:post)
+          .with(endpoint, headers: client.headers, body: request_body.to_json)
+          .and_return(mock_response)
+      end
+
+      it "raises a JSON::ParserError" do
+        expect { client.create_database_item(database_id: database_id, properties: properties) }
+          .to raise_error(JSON::ParserError)
+      end
+    end
+
+    context "when called with empty properties" do
+      let(:empty_properties) { {} }
+      let(:empty_request_body) do
+        {
+          parent: { database_id: database_id },
+          properties: empty_properties
+        }
+      end
+      let(:mock_response) do
+        double("HTTParty::Response",
+               code: 200,
+               body: { "object" => "page", "id" => "new-page-id" }.to_json)
+      end
+
+      before do
+        allow(HTTParty).to receive(:post)
+          .with(endpoint, headers: client.headers, body: empty_request_body.to_json)
+          .and_return(mock_response)
+      end
+
+      it "sends request with empty properties object" do
+        client.create_database_item(database_id: database_id, properties: empty_properties)
+        expect(HTTParty).to have_received(:post)
+          .with(endpoint, headers: client.headers, body: empty_request_body.to_json)
+      end
+
+      it "returns parsed JSON response" do
+        result = client.create_database_item(database_id: database_id, properties: empty_properties)
+        expect(result).to eq({ "object" => "page", "id" => "new-page-id" })
+      end
+    end
+
+    context "when response body is empty" do
+      let(:mock_response) do
+        double("HTTParty::Response",
+               code: 200,
+               body: "")
+      end
+
+      before do
+        allow(HTTParty).to receive(:post)
+          .with(endpoint, headers: client.headers, body: request_body.to_json)
+          .and_return(mock_response)
+      end
+
+      it "raises a JSON::ParserError" do
+        expect { client.create_database_item(database_id: database_id, properties: properties) }
+          .to raise_error(JSON::ParserError)
+      end
+    end
+  end
+
+  describe "#update_database_item" do
+    let(:item_id) { "12345678-1234-1234-1234-123456789abc" }
+    let(:properties) do
+      {
+        "Name" => {
+          "title" => [
+            {
+              "text" => {
+                "content" => "Updated Item"
+              }
+            }
+          ]
+        },
+        "Status" => {
+          "select" => {
+            "name" => "Completed"
+          }
+        }
+      }
+    end
+    let(:endpoint) { "https://api.notion.com/v1/pages/#{item_id}" }
+    let(:request_body) do
+      {
+        properties: properties
+      }
+    end
+    let(:sample_response) do
+      {
+        "object" => "page",
+        "id" => item_id,
+        "created_time" => "2023-01-01T00:00:00.000Z",
+        "last_edited_time" => "2023-01-02T00:00:00.000Z",
+        "properties" => properties
+      }
+    end
+
+    context "when API call is successful" do
+      let(:mock_response) do
+        double("HTTParty::Response",
+               code: 200,
+               body: sample_response.to_json)
+      end
+
+      before do
+        allow(HTTParty).to receive(:patch)
+          .with(endpoint, headers: client.headers, body: request_body.to_json)
+          .and_return(mock_response)
+      end
+
+      it "returns parsed JSON response" do
+        result = client.update_database_item(item_id: item_id, properties: properties)
+        expect(result).to eq(sample_response)
+      end
+
+      it "calls HTTParty.patch with correct parameters" do
+        client.update_database_item(item_id: item_id, properties: properties)
+        expect(HTTParty).to have_received(:patch)
+          .with(endpoint, headers: client.headers, body: request_body.to_json)
+      end
+    end
+
+    context "when API call fails with 400 Bad Request" do
+      let(:mock_response) do
+        double("HTTParty::Response",
+               code: 400,
+               message: "Bad Request")
+      end
+
+      before do
+        allow(HTTParty).to receive(:patch)
+          .with(endpoint, headers: client.headers, body: request_body.to_json)
+          .and_return(mock_response)
+      end
+
+      it "raises an error with appropriate message" do
+        expect { client.update_database_item(item_id: item_id, properties: properties) }
+          .to raise_error(RuntimeError, "Notion API Error: 400, Bad Request")
+      end
+    end
+
+    context "when API call fails with 401 Unauthorized" do
+      let(:mock_response) do
+        double("HTTParty::Response",
+               code: 401,
+               message: "Unauthorized")
+      end
+
+      before do
+        allow(HTTParty).to receive(:patch)
+          .with(endpoint, headers: client.headers, body: request_body.to_json)
+          .and_return(mock_response)
+      end
+
+      it "raises an error with appropriate message" do
+        expect { client.update_database_item(item_id: item_id, properties: properties) }
+          .to raise_error(RuntimeError, "Notion API Error: 401, Unauthorized")
+      end
+    end
+
+    context "when API call fails with 404 Not Found" do
+      let(:mock_response) do
+        double("HTTParty::Response",
+               code: 404,
+               message: "Not Found")
+      end
+
+      before do
+        allow(HTTParty).to receive(:patch)
+          .with(endpoint, headers: client.headers, body: request_body.to_json)
+          .and_return(mock_response)
+      end
+
+      it "raises an error with appropriate message" do
+        expect { client.update_database_item(item_id: item_id, properties: properties) }
+          .to raise_error(RuntimeError, "Notion API Error: 404, Not Found")
+      end
+    end
+
+    context "when API call fails with 500 Internal Server Error" do
+      let(:mock_response) do
+        double("HTTParty::Response",
+               code: 500,
+               message: "Internal Server Error")
+      end
+
+      before do
+        allow(HTTParty).to receive(:patch)
+          .with(endpoint, headers: client.headers, body: request_body.to_json)
+          .and_return(mock_response)
+      end
+
+      it "raises an error with appropriate message" do
+        expect { client.update_database_item(item_id: item_id, properties: properties) }
+          .to raise_error(RuntimeError, "Notion API Error: 500, Internal Server Error")
+      end
+    end
+
+    context "when response body contains invalid JSON" do
+      let(:mock_response) do
+        double("HTTParty::Response",
+               code: 200,
+               body: "{invalid json}")
+      end
+
+      before do
+        allow(HTTParty).to receive(:patch)
+          .with(endpoint, headers: client.headers, body: request_body.to_json)
+          .and_return(mock_response)
+      end
+
+      it "raises a JSON::ParserError" do
+        expect { client.update_database_item(item_id: item_id, properties: properties) }
+          .to raise_error(JSON::ParserError)
+      end
+    end
+
+    context "when called with empty properties" do
+      let(:empty_properties) { {} }
+      let(:empty_request_body) do
+        {
+          properties: empty_properties
+        }
+      end
+      let(:mock_response) do
+        double("HTTParty::Response",
+               code: 200,
+               body: { "object" => "page", "id" => item_id }.to_json)
+      end
+
+      before do
+        allow(HTTParty).to receive(:patch)
+          .with(endpoint, headers: client.headers, body: empty_request_body.to_json)
+          .and_return(mock_response)
+      end
+
+      it "sends request with empty properties object" do
+        client.update_database_item(item_id: item_id, properties: empty_properties)
+        expect(HTTParty).to have_received(:patch)
+          .with(endpoint, headers: client.headers, body: empty_request_body.to_json)
+      end
+
+      it "returns parsed JSON response" do
+        result = client.update_database_item(item_id: item_id, properties: empty_properties)
+        expect(result).to eq({ "object" => "page", "id" => item_id })
+      end
+    end
+
+    context "when response body is empty" do
+      let(:mock_response) do
+        double("HTTParty::Response",
+               code: 200,
+               body: "")
+      end
+
+      before do
+        allow(HTTParty).to receive(:patch)
+          .with(endpoint, headers: client.headers, body: request_body.to_json)
+          .and_return(mock_response)
+      end
+
+      it "raises a JSON::ParserError" do
+        expect { client.update_database_item(item_id: item_id, properties: properties) }
+          .to raise_error(JSON::ParserError)
+      end
+    end
+  end
+
   describe "integration with real endpoint structure" do
     it "constructs correct endpoint URL" do
       expect(HTTParty).to receive(:get)
@@ -211,6 +635,22 @@ RSpec.describe Crs::Notion::Client do
         .and_return(double("response", code: 200, body: "{}"))
 
       client.get_page(id: page_id)
+    end
+
+    it "constructs correct endpoint URL for database item creation" do
+      expect(HTTParty).to receive(:post)
+        .with("https://api.notion.com/v1/pages", hash_including(:headers, :body))
+        .and_return(double("response", code: 200, body: "{}"))
+
+      client.create_database_item(database_id: "test-db-id", properties: {})
+    end
+
+    it "constructs correct endpoint URL for database item update" do
+      expect(HTTParty).to receive(:patch)
+        .with("https://api.notion.com/v1/pages/test-item-id", hash_including(:headers, :body))
+        .and_return(double("response", code: 200, body: "{}"))
+
+      client.update_database_item(item_id: "test-item-id", properties: {})
     end
   end
 end


### PR DESCRIPTION
## 動作確認内容
次のようなコードで実際に呼び出して動作確認を行いました。
```rb
$LOAD_PATH.unshift(File.expand_path("./lib"))

require "crs/notion/client"
require "json"

# Notion APIトークンを設定
notion_token = 'sample'
database_id = 'sample'

client = Crs::Notion::Client.new(notion_token: notion_token)

response_body = client.create_database_item(
  database_id: notion_jims_todo_database_id,
  properties: {
    "Name": {
      "title": [
        { "text": { "content": "アイテムのタイトル" } }
      ]
    }
  }
)

client.update_database_item(
  item_id: response_body['id'],
  properties: {
    "Name": {
      "title": [
        { "text": { "content": "更新後のアイテムのタイトル" } }
      ]
    }
  }
)

```